### PR TITLE
Don't attempt to issue an ec2/DescribeInstances request if no instance IDs were found

### DIFF
--- a/main.go
+++ b/main.go
@@ -286,6 +286,10 @@ func StringToStarString(s []string) []*string {
 // It is unpaginated because the API function does not require
 // pagination.
 func DescribeInstancesUnpaginated(svcec2 *ec2.EC2, instanceIds []string) ([]*ec2.Instance, error) {
+	if len(instanceIds) == 0 {
+		return nil, nil
+	}
+
 	input := &ec2.DescribeInstancesInput{
 		InstanceIds: StringToStarString(instanceIds),
 	}

--- a/main.go
+++ b/main.go
@@ -352,6 +352,9 @@ func AddContainerInstancesToTasks(svc *ecs.ECS, svcec2 *ec2.EC2, taskList []*Aug
 			instanceIDToEC2Instance[*ci.Ec2InstanceId] = nil
 		}
 	}
+	if len(instanceIDToEC2Instance) == 0 {
+		return taskList, nil
+	}
 
 	keys := make([]string, 0, len(instanceIDToEC2Instance))
 	for id, _ := range instanceIDToEC2Instance {


### PR DESCRIPTION
In a Fargate-only ECS cluster, there are no EC2 instances. In such a scenario, the following erroneous (and useless) `ec2/DescribeInstances` request is issued:

```
2018/04/24 17:08:32 DEBUG: Request ec2/DescribeInstances Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST / HTTP/1.1
Host: ec2.us-east-1.amazonaws.com
User-Agent: aws-sdk-go/1.13.8 (go1.10.1; darwin; amd64)
Content-Length: 55
Content-Type: application/x-www-form-urlencoded; charset=utf-8
X-Amz-Date: 20180424T210832Z
Accept-Encoding: gzip

Action=DescribeInstances&InstanceId=&Version=2016-11-15
-----------------------------------------------------
2018/04/24 17:08:32 DEBUG: Response ec2/DescribeInstances Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 Bad Request
Connection: close
Transfer-Encoding: chunked
Date: Tue, 24 Apr 2018 21:08:31 GMT
Server: AmazonEC2


-----------------------------------------------------
2018/04/24 17:08:32 <?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>MissingParameter</Code><Message>The request must contain the parameter InstanceId</Message></Error></Errors><RequestID>067478b2-ff82-4dd8-a784-6c8227c40225</RequestID></Response>
2018/04/24 17:08:32 MissingParameter: The request must contain the parameter InstanceId
        status code: 400, request id: 067478b2-ff82-4dd8-a784-6c8227c40225
```

This PR elides the call when no instance IDs are available.