### PR TITLE
Use correct error var, to print out correct message

### DIFF
--- a/main.go
+++ b/main.go
@@ -400,7 +400,7 @@ func GetTasksOfClusters(svc *ecs.ECS, svcec2 *ec2.EC2, clusterArns []*string) ([
 				var err error
 				for {
 					output, err1 := svc.ListTasks(input)
-					if err != nil {
+					if err1 != nil {
 						err = err1
 						log.Printf("Error listing tasks of cluster %s: %s", *clusterArn, err)
 						break


### PR DESCRIPTION
If, say, you misconfigure your IAM permissions (who would do that? no idea! ...) then this would not print out the error message, but instead fail silently (and return no tasks).

