### PR TITLE
Support services using 'awsvpc' network mode.

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,13 +187,12 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 			continue
 		}
 
-		if *t.LaunchType != "FARGATE" {
-			// for _, nb := range i.NetworkBindings {
-			// 	if int(*nb.ContainerPort) == exporterPort {
-			// 		hostPort = *nb.HostPort
-			// 	}
-			// }
-			hostPort = int64(exporterPort)
+		if len(i.NetworkBindings) > 0 {
+			for _, nb := range i.NetworkBindings {
+				if int(*nb.ContainerPort) == exporterPort {
+					hostPort = *nb.HostPort
+				}
+			}
 		} else {
 			for _, ni := range i.NetworkInterfaces {
 				if *ni.PrivateIpv4Address != "" {
@@ -202,7 +201,6 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 			}
 			hostPort = int64(exporterPort)
 		}
-
 
 		if exporterServerName, ok = d.DockerLabels["PROMETHEUS_EXPORTER_SERVER_NAME"]; ok {
 			host = strings.TrimRight(*exporterServerName, "/")

--- a/main.go
+++ b/main.go
@@ -188,11 +188,12 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 		}
 
 		if *t.LaunchType != "FARGATE" {
-			for _, nb := range i.NetworkBindings {
-				if int(*nb.ContainerPort) == exporterPort {
-					hostPort = *nb.HostPort
-				}
-			}
+			// for _, nb := range i.NetworkBindings {
+			// 	if int(*nb.ContainerPort) == exporterPort {
+			// 		hostPort = *nb.HostPort
+			// 	}
+			// }
+			hostPort = int64(exporterPort)
 		} else {
 			for _, ni := range i.NetworkInterfaces {
 				if *ni.PrivateIpv4Address != "" {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -500,9 +501,14 @@ func GetAugmentedTasks(svc *ecs.ECS, svcec2 *ec2.EC2, clusterArns []*string) ([]
 
 func main() {
 	flag.Parse()
-	sess := session.New()
+
+	config := aws.NewConfig().WithCredentialsChainVerboseErrors(true)
+
+	// Initialise AWS Service clients
+	sess := session.New(config)
 	svc := ecs.New(sess)
 	svcec2 := ec2.New(sess)
+
 	work := func() {
 		clusters, err := GetClusters(svc)
 		if err != nil {


### PR DESCRIPTION
We have some services using `awsvpc` network mode, which in essence is something similar as what `FARGATE` does, and this tool wasn't able to populate Prometheus' config file properly since those type of ECS services won't show any _NetworkBinding_ configuration.

The small change shown here solves that issue whilst still should work for containers in the other supported network modes.