### PR TITLE
Fix hosts ip for ecs tasks

### DIFF
--- a/main.go
+++ b/main.go
@@ -398,8 +398,9 @@ func AddContainerInstancesToTasks(svc *ecs.ECS, svcec2 *ec2.EC2, taskList []*Aug
 		return nil, err
 	}
 
-	for _, i := range instances {
-		instanceIDToEC2Instance[*i.InstanceId] = &i
+	for i := 0; i < len(instances); i++ { 
+		inst := instances[i]
+		instanceIDToEC2Instance[*inst.InstanceId] = &inst
 	}
 
 	for _, task := range taskList {

--- a/main.go
+++ b/main.go
@@ -398,9 +398,9 @@ func AddContainerInstancesToTasks(svc *ecs.ECS, svcec2 *ec2.EC2, taskList []*Aug
 		return nil, err
 	}
 
-	for i := 0; i < len(instances); i++ { 
-		inst := instances[i]
-		instanceIDToEC2Instance[*inst.InstanceId] = &inst
+	for _, i := range instances {
+        	inst := i
+		instanceIDToEC2Instance[*i.InstanceId] = &inst
 	}
 
 	for _, task := range taskList {


### PR DESCRIPTION
I have fixed the host IP for each task because currently it retrieves always the same IP for all the ECS tasks because of there is a "for each" loop and the memory position for the "for each" var is being associated in each iteration, so it is overrided