### PR TITLE
Implement support for multiple role-ARNS (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The command line parameters that can be used are:
   exiting (0 = infinite)
 * -config.write-to (string): path of file to write ECS service
   discovery information to (default "ecs_file_sd.yml")
-* -config.role-arn (string): ARN of the role to assume when scraping
-  the AWS API (optional)
+* -config.role-arns string
+  comma-separated list of role-ARNs to assume when scraping the AWS API (optional)
 * -config.server-name-label (string): Docker label to define the server name
   (default "PROMETHEUS_EXPORTER_SERVER_NAME")
 * -config.path-label (string): Docker label to define the scrape path of the
@@ -41,8 +41,8 @@ Then, run it as follows:
   `ECS:ListTasks`, `ECS:DescribeTask`, `EC2:DescribeInstances`,
   `ECS:DescribeContainerInstances`, `ECS:DescribeTasks`,
   `ECS:DescribeTaskDefinition`). If the program needs to assume
-  a different role to obtain access, this role's ARN may be
-  passed in via the `--config.role-arn` option. This option also
+  different role(s) to obtain access, the roles' ARNs may be
+  passed in via the `--config.role-arns` option. This option also
   allows for cross-account access, depending on which account
   the role is defined in.
 * Start the program, using the command line option

--- a/main.go
+++ b/main.go
@@ -580,7 +580,10 @@ func main() {
 					return
 				}
 				config.Credentials = stscreds.NewAssumeRoleProvider(stsSvc, arn)
-				infos = runDiscovery(&config, infos)
+				result := runDiscovery(&config, infos)
+				if result != nil {
+					infos = append(infos, result...)
+				}
 			}
 		} else {
 			infos = runDiscovery(&defaultConfig, infos)


### PR DESCRIPTION
This adds support for multiple role-ARNs to allow scraping from multiple AWS accounts during the same run. Only breaking change is the commandline parameter, which has been changed from -config.role-arn to -config.role-arns. 