### PR TITLE
support job name label

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The command line parameters that can be used are:
   the AWS API (optional)
 * -config.server-name-label (string): Docker label to define the server name
   (default "PROMETHEUS_EXPORTER_SERVER_NAME")
+* -config.job-name-label (string): Docker label to define the job name
+  (default "PROMETHEUS_EXPORTER_JOB_NAME")
 * -config.path-label (string): Docker label to define the scrape path of the
   application (default "PROMETHEUS_EXPORTER_PATH")
 * -config.port-label (string): Docker label to define the scrape port of the application
@@ -57,12 +59,17 @@ scrape_configs:
     - files:
       - /path/to/ecs_file_sd.yml
       refresh_interval: 10m
+  # Drop unwanted labels using the labeldrop action
+  metric_relabel_configs:
+    - regex: task_arn
+      action: labeldrop
 ```
 
 To scrape the containers add following docker labels to them:
 
 * `PROMETHEUS_EXPORTER_PORT` specify the container port where prometheus scrapes (mandatory)
 * `PROMETHEUS_EXPORTER_SERVER_NAME` specify the hostname here, per default ip is used (optional)
+* `PROMETHEUS_EXPORTER_JOB_NAME` specify job name here (optional)
 * `PROMETHEUS_EXPORTER_PATH` specify alternative scrape path here (optional)
 
 That's it.  You should begin seeing the program scraping the

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 type labels struct {
 	TaskArn       string `yaml:"task_arn"`
 	TaskName      string `yaml:"task_name"`
+	JobName       string `yaml:"job,omitempty"`
 	TaskRevision  string `yaml:"task_revision"`
 	TaskGroup     string `yaml:"task_group"`
 	ClusterArn    string `yaml:"cluster_arn"`
@@ -51,6 +52,7 @@ var roleArn = flag.String("config.role-arn", "", "ARN of the role to assume when
 var prometheusPortLabel = flag.String("config.port-label", "PROMETHEUS_EXPORTER_PORT", "Docker label to define the scrape port of the application (if missing an application won't be scraped)")
 var prometheusPathLabel = flag.String("config.path-label", "PROMETHEUS_EXPORTER_PATH", "Docker label to define the scrape path of the application")
 var prometheusServerNameLabel = flag.String("config.server-name-label", "PROMETHEUS_EXPORTER_SERVER_NAME", "Docker label to define the server name")
+var prometheusJobNameLabel = flag.String("config.job-name-label", "PROMETHEUS_EXPORTER_JOB_NAME", "Docker label to define the job name")
 
 // logError is a convenience function that decodes all possible ECS
 // errors and displays them to standard error.
@@ -233,6 +235,7 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 		labels := labels{
 			TaskArn:       *t.TaskArn,
 			TaskName:      *t.TaskDefinition.Family,
+			JobName:       d.DockerLabels[*prometheusJobNameLabel],
 			TaskRevision:  fmt.Sprintf("%d", *t.TaskDefinition.Revision),
 			TaskGroup:     *t.Group,
 			ClusterArn:    *t.ClusterArn,


### PR DESCRIPTION
This allows the scraper to pull the "job" label from the Docker label "PROMETHEUS_EXPORTER_JOB_NAME".