### PR TITLE
add option limit the scraper to a single cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Run `prometheus-ecs-discovery --help` to get information.
 
 The command line parameters that can be used are:
 
+* -config.cluster (string): the name of a cluster to scrape (defaults to scraping all clusters)
 * -config.scrape-interval (duration): interval at which to scrape
   the AWS API for ECS service discovery information (default 1m0s)
 * -config.scrape-times (int): how many times to scrape before

--- a/main.go
+++ b/main.go
@@ -554,6 +554,22 @@ func main() {
 		var clusters *ecs.ListClustersOutput
 
 		if *cluster != "" {
+			res, err := svc.DescribeClustersRequest(&ecs.DescribeClustersInput{
+				Clusters: []string{*cluster},
+			}).Send()
+			if err != nil {
+				logError(err)
+				return
+			}
+
+			if len(res.Clusters) == 0 {
+				logError(fmt.Errorf(
+					"%s cluster not found",
+					ecs.ErrCodeClusterNotFoundException,
+				))
+				return
+			}
+
 			clusters = &ecs.ListClustersOutput{
 				ClusterArns: []string{*cluster},
 			}


### PR DESCRIPTION
This allows the operator to select a single cluster to scrape. Useful for scenarios where separate Prometheus instances are used for different clusters (f.ex. test/prod clusters).