### PR TITLE
pass the background context to send call of aws api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/teralytics/prometheus-ecs-discovery
 
 require (
-	github.com/aws/aws-sdk-go-v2 v0.7.0
+	github.com/aws/aws-sdk-go-v2 v0.8.0
 	github.com/go-yaml/yaml v2.1.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go-v2 v0.7.0 h1:a5xRI/tBmUFKuAA0SOyEY2P1YhQb+jVOEI9P/7KfrP0=
-github.com/aws/aws-sdk-go-v2 v0.7.0/go.mod h1:17MaCZ9g0q5BIMxwzRQeiv8M3c8+W7iuBnlWAEprcxE=
+github.com/aws/aws-sdk-go-v2 v0.8.0 h1:IyCzxvwRVe2ehXfi7YMsVxaVU6JvaH58ZO7uPFS3HlY=
+github.com/aws/aws-sdk-go-v2 v0.8.0/go.mod h1:sa1GePZ/LfBGI4dSq30f6uR4Tthll8axxtEPvlpXZ8U=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=


### PR DESCRIPTION
The aws sdk now require the context to be passed on each call. to Send() This caused a build error when executing `go get github.com/teralytics/prometheus-ecs-discovery`. 

Fixes #40