### PR TITLE
[WIP] Fix wrong IP-address (handle disordered enis list)

### DIFF
--- a/main.go
+++ b/main.go
@@ -169,8 +169,11 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 		if len(t.EC2Instance.NetworkInterfaces) == 0 {
 			return ret
 		}
+
 		for _, iface := range t.EC2Instance.NetworkInterfaces {
-			if iface.PrivateIpAddress != nil && *iface.PrivateIpAddress != "" {
+			if iface.PrivateIpAddress != nil && *iface.PrivateIpAddress != "" &&
+				iface.PrivateDnsName != nil && *iface.PrivateDnsName != "" &&
+				*iface.PrivateDnsName == *t.EC2Instance.PrivateDnsName {
 				ip = *iface.PrivateIpAddress
 				break
 			}


### PR DESCRIPTION
For one of the ecs task which is running in bridge mode, it returned wrong ip address. As the task is running in bridge mode it is supposed to get instance ip address but instead it got ip address from some other eni attached to the same instance.

The possible reason behind this is the wrong order of network interfaces of the instance.
<img width="905" alt="Screenshot 2019-12-19 at 9 45 29 PM" src="https://user-images.githubusercontent.com/16459106/71189516-f6483980-22a8-11ea-8173-cbbb17c88fb5.png">
This is not in the order of DeviceIndex.
For this list of enis, current logic will return 192.168.201.223 as primary address of the instance which is not the case.

Hence adding some extra checks to make sure that default ip address is the primary ip address.