### PR TITLE
Discover multiple ports for single container

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ If your container exposes metrics on more than one port for a single task you ca
 * `PROMETHEUS_EXPORTER_PORT.1` `9180` - Set the first port exposing metrics 
 * `PROMETHEUS_EXPORTER_PORT.2` `8080` - Set the second port exposing metrics
 * `PROMETHEUS_EXPORTER_PATH.2` `/api/v1/metrics` - The second port exposes metrics on a non-standard path of `/api/v1/metrics` 
+* `PROMETHEUS_EXPORTER_JOB_NAME.2` `logging` - The second port has a separate job name, `logging`, useful for differentiating otherwise identical metrics

--- a/README.md
+++ b/README.md
@@ -80,3 +80,11 @@ that every minute, and by default Prometheus will reload the
 file the minute it is written).  After reloading your Prometheus
 master configuration, this program will begin informing via
 the discovery file of new targets that Prometheus must scrape.
+
+### Multiple Ports
+
+If your container exposes metrics on more than one port for a single task you can use multiple labels as so:
+
+* `PROMETHEUS_EXPORTER_PORT.1` `9180` - Set the first port exposing metrics 
+* `PROMETHEUS_EXPORTER_PORT.2` `8080` - Set the second port exposing metrics
+* `PROMETHEUS_EXPORTER_PATH.2` `/api/v1/metrics` - The second port exposes metrics on a non-standard path of `/api/v1/metrics` 

--- a/main.go
+++ b/main.go
@@ -293,6 +293,7 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 			}
 			var exporterServerName string
 			var exporterPath string
+			var exporterJobName string
 			var ok bool
 			exporterServerName, ok = d.DockerLabels[*prometheusServerNameLabel]
 			if ok {
@@ -318,6 +319,11 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 				exporterPath, ok = d.DockerLabels[*prometheusPathLabel+key]
 				if ok {
 					labels.MetricsPath = exporterPath
+				}
+
+				exporterJobName, ok = d.DockerLabels[*prometheusJobNameLabel+key]
+				if ok {
+					labels.JobName = exporterJobName
 				}
 
 				ret = append(ret, &PrometheusTaskInfo{

--- a/main.go
+++ b/main.go
@@ -232,12 +232,16 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 			var exporterPort int
 			for key := range d.DockerLabels {
 				result := re.FindAllSubmatch([]byte(key), -1)
+				if len(result) == 0 {
+					continue
+				}
+
 				var portString string
 				var portName string
-				if len(result) == 1 || len(result) == 2 {
+				if len(result[0]) == 1 || len(result[0]) == 2 {
 					portString = d.DockerLabels[string(result[0][0])]
 					portName = ""
-				} else if len(result) > 2 {
+				} else if len(result[0]) > 2 {
 					portString = d.DockerLabels[string(result[0][0])]
 					portName = string(result[0][2])
 				} else {


### PR DESCRIPTION
Hi there,

In reference to https://github.com/teralytics/prometheus-ecs-discovery/issues/37 this change let's you use `PROMETHEUS_EXPORTER_PORT.1` and an optional corresponding `PROMETHEUS_EXPORTER_PATH.1` without breaking the original functionality of `PROMETHEUS_EXPORTER_PORT` without a suffix.

Cheers,
Dirk