### PR TITLE
Add hostPort check

### DIFF
--- a/main.go
+++ b/main.go
@@ -266,6 +266,13 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 			}
 		}
 
+		if hostPort == 0 {
+			// This container has network bindings but none have a container port matching the exporter port.
+			// Since the host port is mandatory for the generated Prometheus config and host port 0 does
+			// not make sense, this container will be skipped.
+			continue
+		}
+
 		var exporterServerName string
 		var exporterPath string
 		var ok bool


### PR DESCRIPTION
If the container has network bindings but none have a container port
matching the exporter port, hostPort will have a value of 0 which does
not make sense. So if hostPort is 0, we just skip the container.

We've hit this issue where the generated Prometheus config contained targets hosts with port 0.