### PR TITLE
Add functionality to configure target URL scheme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ To scrape the containers add following docker labels to them:
 * `PROMETHEUS_EXPORTER_SERVER_NAME` specify the hostname here, per default ip is used (optional)
 * `PROMETHEUS_EXPORTER_JOB_NAME` specify job name here (optional)
 * `PROMETHEUS_EXPORTER_PATH` specify alternative scrape path here (optional)
+* `PROMETHEUS_EXPORTER_SCHEME` specify an alternative scheme here, default is http (optional)
 
 That's it.  You should begin seeing the program scraping the
 AWS APIs and writing the discovery file (by default it does

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ type labels struct {
 	ContainerArn  string `yaml:"container_arn"`
 	DockerImage   string `yaml:"docker_image"`
 	MetricsPath   string `yaml:"__metrics_path__,omitempty"`
+	Scheme        string `yaml:"__scheme__,omitempty"`
 }
 
 // Docker label for enabling dynamic port detection
@@ -55,6 +56,7 @@ var times = flag.Int("config.scrape-times", 0, "how many times to scrape before 
 var roleArn = flag.String("config.role-arn", "", "ARN of the role to assume when scraping the AWS API (optional)")
 var prometheusPortLabel = flag.String("config.port-label", "PROMETHEUS_EXPORTER_PORT", "Docker label to define the scrape port of the application (if missing an application won't be scraped)")
 var prometheusPathLabel = flag.String("config.path-label", "PROMETHEUS_EXPORTER_PATH", "Docker label to define the scrape path of the application")
+var prometheusSchemeLabel= flag.String("config.scheme-label", "PROMETHEUS_EXPORTER_SCHEME", "Docker label to define the scheme of the target application")
 var prometheusFilterLabel = flag.String("config.filter-label", "", "Docker label (and optionally value) to require to scrape the application")
 var prometheusServerNameLabel = flag.String("config.server-name-label", "PROMETHEUS_EXPORTER_SERVER_NAME", "Docker label to define the server name")
 var prometheusJobNameLabel = flag.String("config.job-name-label", "PROMETHEUS_EXPORTER_JOB_NAME", "Docker label to define the job name")
@@ -268,6 +270,7 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 
 		var exporterServerName string
 		var exporterPath string
+		var scheme string
 		var ok bool
 		exporterServerName, ok = d.DockerLabels[*prometheusServerNameLabel]
 		if ok {
@@ -292,6 +295,11 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 		exporterPath, ok = d.DockerLabels[*prometheusPathLabel]
 		if ok {
 			labels.MetricsPath = exporterPath
+		}
+
+		scheme, ok = d.DockerLabels[*prometheusSchemeLabel]
+		if ok {
+		    labels.Scheme = scheme
 		}
 
 		ret = append(ret, &PrometheusTaskInfo{


### PR DESCRIPTION
Wanted to scrape a encrypted task, so added the option to provide your own scheme to Prometheus through a Docker label.