### PR TITLE
Fix ListClusters failure when there are more than 100 clusters

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,10 +97,10 @@ func GetClusters(svc *ecs.ECS) (*ecs.ListClustersOutput, error) {
 			return nil, err
 		}
 		output.ClusterArns = append(output.ClusterArns, myoutput.ClusterArns...)
-		if output.NextToken == nil {
+		if myoutput.NextToken == nil {
 			break
 		}
-		input.NextToken = output.NextToken
+		input.NextToken = myoutput.NextToken
 	}
 	return output, nil
 }


### PR DESCRIPTION
Fix a bug in the ListClusters pagination code.

We were checking the 'NextToken' of our response object, not the response object from the SDK.

This was always nil, so we only collected the first page of results from the API.