### PR TITLE
update golang version to 1.15-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine
+FROM golang:1.15-alpine
 WORKDIR /src
 RUN apk --no-cache add git
 COPY *.go go.mod go.sum ./


### PR DESCRIPTION
Docker build was failing due to dependencies requiring golang 1.15. Updated version in Dockerfile.