### PR TITLE
Build Image from Scratch instead of Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM golang:1.15-alpine
 WORKDIR /src
-RUN apk --no-cache add git
+RUN apk --no-cache add \
+      git \
+      ca-certificates
 COPY *.go go.mod go.sum ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /bin/prometheus-ecs-discovery .
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM scratch
 COPY --from=0 /bin/prometheus-ecs-discovery /bin/
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["prometheus-ecs-discovery"]


### PR DESCRIPTION
Hi folks, 
this PR aims to clean up the resulting Docker Image by getting rid of Alpine and just building the image from scratch. 
Resulting image will only include ca-certificates and the binary. 

Regards