### PR TITLE
Removing Fargate Detecting Condition 

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,7 +192,8 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 				break
 			}
 		}
-		if *i.Name != *d.Name && t.LaunchType != ecstypes.LaunchTypeFargate {
+        // Removing '&& t.LaunchType != ecstypes.LaunchTypeFargate' condition because ECS service connect creates container not described on container defintions and causes a duplicated target.
+		if *i.Name != *d.Name {
 			// Nope, no match, this container cannot be exported.  We continue.
 			continue
 		}


### PR DESCRIPTION
In 2022, AWS announced the new feature ECS Service Connect which helps to create service mesh feature easily.
The service connect container is not described on Task definition, but described on tasks.
Since Name checking between task's container and task definition's container is not applied when ecs runs on a fargate, there is a case that target is created for ecs service connect container.
This problem solved with this commit.
