### PR TITLE
fix: use ipv4 port

### DIFF
--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 
 			if len(i.NetworkBindings) > 0 {
 				for _, nb := range i.NetworkBindings {
-					if int(*nb.ContainerPort) == exporterPort {
+					if int(*nb.ContainerPort) == exporterPort && *nb.BindIP == "0.0.0.0" {
 						hostPort = *nb.HostPort
 					}
 				}


### PR DESCRIPTION
By default it writes the ipv6 port and ipv4 address to the service discovery output file, with this patch the ipv4 port will be written