### PR TITLE
Custom docker label parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -312,6 +312,11 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 		var prometheusJobLabel string
 		if prometheusJobNameLabelOverride != "" {
 			prometheusJobLabel = prometheusJobNameLabelOverride
+
+			// some extra parsing to remove unneccessary prefix
+			prometheusJobLabel = strings.TrimPrefix(prometheusJobLabel, "service:")
+			prometheusJobLabel = strings.TrimPrefix(prometheusJobLabel, "service=")
+
 		} else {
 			prometheusJobLabel = d.DockerLabels[*prometheusJobNameLabel]
 		}

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ var times = flag.Int("config.scrape-times", 0, "how many times to scrape before 
 var roleArn = flag.String("config.role-arn", "", "ARN of the role to assume when scraping the AWS API (optional)")
 var prometheusPortLabel = flag.String("config.port-label", "PROMETHEUS_EXPORTER_PORT", "Docker label to define the scrape port of the application (if missing an application won't be scraped)")
 var prometheusPathLabel = flag.String("config.path-label", "PROMETHEUS_EXPORTER_PATH", "Docker label to define the scrape path of the application")
-var prometheusSchemeLabel= flag.String("config.scheme-label", "PROMETHEUS_EXPORTER_SCHEME", "Docker label to define the scheme of the target application")
+var prometheusSchemeLabel = flag.String("config.scheme-label", "PROMETHEUS_EXPORTER_SCHEME", "Docker label to define the scheme of the target application")
 var prometheusFilterLabel = flag.String("config.filter-label", "", "Docker label (and optionally value) to require to scrape the application")
 var prometheusServerNameLabel = flag.String("config.server-name-label", "PROMETHEUS_EXPORTER_SERVER_NAME", "Docker label to define the server name")
 var prometheusJobNameLabel = flag.String("config.job-name-label", "PROMETHEUS_EXPORTER_JOB_NAME", "Docker label to define the job name")
@@ -131,25 +131,26 @@ type PrometheusTaskInfo struct {
 // container in the task has a PROMETHEUS_EXPORTER_PORT
 //
 // Example:
-//     ...
-//             "Name": "apache",
-//             "DockerLabels": {
-//                  "PROMETHEUS_EXPORTER_PORT": "1234"
-//              },
-//     ...
-//              "PortMappings": [
-//                {
-//                  "ContainerPort": 1883,
-//                  "HostPort": 0,
-//                  "Protocol": "tcp"
-//                },
-//                {
-//                  "ContainerPort": 1234,
-//                  "HostPort": 0,
-//                  "Protocol": "tcp"
-//                }
-//              ],
-//     ...
+//
+//	...
+//	        "Name": "apache",
+//	        "DockerLabels": {
+//	             "PROMETHEUS_EXPORTER_PORT": "1234"
+//	         },
+//	...
+//	         "PortMappings": [
+//	           {
+//	             "ContainerPort": 1883,
+//	             "HostPort": 0,
+//	             "Protocol": "tcp"
+//	           },
+//	           {
+//	             "ContainerPort": 1234,
+//	             "HostPort": 0,
+//	             "Protocol": "tcp"
+//	           }
+//	         ],
+//	...
 func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 	ret := []*PrometheusTaskInfo{}
 	var host string
@@ -198,6 +199,7 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 		}
 
 		var hostPort int32
+		var prometheusJobNameLabelOverride string
 		if *prometheusDynamicPortDetection {
 			v, ok := d.DockerLabels[dynamicPortLabel]
 			if !ok || v != "1" {
@@ -216,8 +218,37 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 				hostPort = *port
 			}
 		} else {
+			// Match label keys like SERVICE_*_NAME (regex: ^SERVICE_.*_NAME$)
+			var isPrometheusExporter bool = false
+			var exporterPort int
+			for label, val := range d.DockerLabels {
+				if strings.HasPrefix(label, "SERVICE_") && strings.HasSuffix(label, "_NAME") && (strings.HasPrefix(val, "prometheus") && strings.HasSuffix(val, "exporter")) {
+					// Extract number between "SERVICE_" and "_NAME"
+					portStr := label[len("SERVICE_") : len(label)-len("_NAME")]
+					if p, err := strconv.Atoi(portStr); err == nil && p > 0 {
+						// Infer exporter port by injecting it into the expected port label
+						d.DockerLabels[*prometheusPortLabel] = strconv.Itoa(p)
+						isPrometheusExporter = true
+						exporterPort = p
+						break
+					}
+				}
+			}
+
+			// infer prometheus exporter job name
+			if isPrometheusExporter {
+				var target string = "SERVICE_" + strconv.Itoa(exporterPort) + "_TAGS"
+				for label, val := range d.DockerLabels {
+					if label == target {
+						// We found the job name label, no need to continue
+						prometheusJobNameLabelOverride = val
+						break
+					}
+				}
+			}
+
 			v, ok := d.DockerLabels[*prometheusPortLabel]
-			if !ok {
+			if !ok && !isPrometheusExporter {
 				// Nope, no Prometheus-exported port in this container def.
 				// This container is no good.  We continue.
 				continue
@@ -235,7 +266,6 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 				}
 			}
 
-			var exporterPort int
 			var err error
 			if exporterPort, err = strconv.Atoi(v); err != nil || exporterPort < 0 {
 				// This container has an invalid port definition.
@@ -278,10 +308,18 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 			host = ip
 		}
 
+		// job name override check - added to infer job name
+		var prometheusJobLabel string
+		if prometheusJobNameLabelOverride != "" {
+			prometheusJobLabel = prometheusJobNameLabelOverride
+		} else {
+			prometheusJobLabel = d.DockerLabels[*prometheusJobNameLabel]
+		}
+
 		labels := labels{
 			TaskArn:       *t.TaskArn,
 			TaskName:      *t.TaskDefinition.Family,
-			JobName:       d.DockerLabels[*prometheusJobNameLabel],
+			JobName:       prometheusJobLabel,
 			TaskRevision:  fmt.Sprintf("%d", t.TaskDefinition.Revision),
 			TaskGroup:     *t.Group,
 			ClusterArn:    *t.ClusterArn,
@@ -297,7 +335,7 @@ func (t *AugmentedTask) ExporterInformation() []*PrometheusTaskInfo {
 
 		scheme, ok = d.DockerLabels[*prometheusSchemeLabel]
 		if ok {
-		    labels.Scheme = scheme
+			labels.Scheme = scheme
 		}
 
 		ret = append(ret, &PrometheusTaskInfo{


### PR DESCRIPTION
Difficulty - leetcode easy string parsing type problem

Description:
- `ecs-prime` cluster services do not have appropriate docker labels for `prometheus-ecs-discovery` to work. This PR adds the neccessary custom logic to infer the port and auto discovery prometheus exporters for services previously setup to be  registered to `consul`